### PR TITLE
fix: fix bug in sampler for DrNAS routine

### DIFF
--- a/examples/experiment_example.py
+++ b/examples/experiment_example.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
-from confopt.profiles import GDASProfile
+from confopt.profiles import GDASProfile, DRNASProfile
 from confopt.train import DatasetType, Experiment, SearchSpaceType
 
 if __name__ == "__main__":
-    searchspace = SearchSpaceType("nb201")
+    searchspace = SearchSpaceType("darts")
     dataset = DatasetType("cifar10")
     seed = 100
 
     # Sampler and Perturbator have different sample_frequency
-    profile = GDASProfile(
+    profile = DRNASProfile(
         is_partial_connection=True,
-        perturbation="random",
+        perturbation="none",
         sampler_sample_frequency="step",
-        perturbator_sample_frequency="epoch",
-        tau_max=20,
-        tau_min=0.2,
+        # perturbator_sample_frequency="epoch",
+        # tau_max=20,
+        # tau_min=0.2,
     )
 
     config = profile.get_config()

--- a/src/confopt/oneshot/archsampler/base_sampler.py
+++ b/src/confopt/oneshot/archsampler/base_sampler.py
@@ -15,8 +15,8 @@ class BaseSampler(OneShotComponent):
         sample_frequency: Literal["epoch", "step"],
     ) -> None:
         super().__init__()
-        self.arch_parameters = arch_parameters
-        self.sampled_alphas: list[torch.Tensor] = arch_parameters
+        self.arch_parameters: list[torch.Tensor] = arch_parameters
+        self.sampled_arch_parameters: list[torch.Tensor] = arch_parameters
 
         assert sample_frequency in [
             "epoch",
@@ -30,25 +30,19 @@ class BaseSampler(OneShotComponent):
     ) -> list[torch.Tensor] | None:
         pass
 
-    def set_arch_parameters_from_sample(self) -> None:
-        assert self.sampled_alphas is not None
-        self.arch_parameters = self.sampled_alphas
-
     def _sample_and_update_alphas(self) -> None:  # type: ignore
         sampled_alphas = self.sample_alphas(self.arch_parameters)
         # print(sampled_alphas)
         if sampled_alphas is not None:
-            self.sampled_alphas = sampled_alphas
+            self.sampled_arch_parameters = sampled_alphas
 
     def new_epoch(self) -> None:
         super().new_epoch()
         if self.sample_frequency == "epoch":
             self._sample_and_update_alphas()
-            self.set_arch_parameters_from_sample()
 
     def new_step(self) -> None:  # type: ignore
         super().new_step()
 
         if self.sample_frequency == "step":
             self._sample_and_update_alphas()
-            self.set_arch_parameters_from_sample()

--- a/src/confopt/profiles/profile_config.py
+++ b/src/confopt/profiles/profile_config.py
@@ -86,7 +86,7 @@ class ProfileConfig:
             "momentum": 0.9,
             "nesterov": 0,
             "criterion": "cross_entropy",
-            "batch_size": 96,
+            "batch_size": 4,
             "learning_rate_min": 0.0,
             "weight_decay": 3e-4,
             "cutout": -1,

--- a/src/confopt/searchspace/common/base_search.py
+++ b/src/confopt/searchspace/common/base_search.py
@@ -21,7 +21,7 @@ class SearchSpace(nn.Module, ABC):
         pass
 
     @abstractmethod
-    def set_arch_parameters(self, arch_parameters: list[nn.Parameter]) -> None:
+    def set_sampled_arch_parameters(self, arch_parameters: list[nn.Parameter]) -> None:
         pass
 
     def model_weight_parameters(self) -> list[nn.Parameter]:
@@ -48,4 +48,4 @@ class SearchSpace(nn.Module, ABC):
                 isinstance(component, BaseSampler)
                 and component.sample_frequency == "step"
             ):
-                self.set_arch_parameters(component.arch_parameters)
+                self.set_sampled_arch_parameters(component.sampled_arch_parameters)

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -53,7 +53,7 @@ class TestArchSamplers(unittest.TestCase):
 
         alphas_before = searchspace.arch_parameters
         self._sampler_new_step_or_epoch(sampler, sample_frequency)
-        alphas_after = sampler.sampled_alphas
+        alphas_after = sampler.sampled_arch_parameters
 
         # assert that the tensors are close
         for arch_param_before, arch_param_after in zip(alphas_before, alphas_after):
@@ -85,7 +85,7 @@ class TestArchSamplers(unittest.TestCase):
 
         alphas_before = searchspace.arch_parameters
         self._sampler_new_step_or_epoch(sampler, sample_frequency)
-        alphas_after = sampler.sampled_alphas
+        alphas_after = sampler.sampled_arch_parameters
 
         for arch_param_before, arch_param_after in zip(alphas_before, alphas_after):
             assert not torch.allclose(arch_param_before, arch_param_after)
@@ -119,7 +119,7 @@ class TestArchSamplers(unittest.TestCase):
 
         alphas_before = searchspace.arch_parameters
         self._sampler_new_step_or_epoch(sampler, sample_frequency)
-        alphas_after = sampler.sampled_alphas
+        alphas_after = sampler.sampled_arch_parameters
 
         for arch_param_before, arch_param_after in zip(alphas_before, alphas_after):
             assert not torch.allclose(arch_param_before, arch_param_after)
@@ -179,7 +179,7 @@ class TestArchSamplers(unittest.TestCase):
         # Random Attack
         alphas_before = searchspace.arch_parameters
         self._sampler_new_step_or_epoch(sampler, sample_frequency)
-        alphas_after = sampler.sampled_alphas
+        alphas_after = sampler.sampled_arch_parameters
 
         for arch_param_before, arch_param_after in zip(alphas_before, alphas_after):
             assert not torch.allclose(arch_param_before, arch_param_after)
@@ -209,7 +209,7 @@ class TestArchSamplers(unittest.TestCase):
 
         alphas_before = searchspace.arch_parameters
         self._sampler_new_step_or_epoch(sampler, sample_frequency)
-        alphas_after = sampler.sampled_alphas
+        alphas_after = sampler.sampled_arch_parameters
 
         for arch_param_before, arch_param_after in zip(alphas_before, alphas_after):
             assert not torch.allclose(arch_param_before, arch_param_after)


### PR DESCRIPTION
This is a proof of concept for the design of the samplers for DrNAS.
In a nutshell, every model maintains two sets of alpha parameters - one for the underlying architectural alphas from which sampling-based optimizers sample, and another for the sampled alphas. Only the latter is consumed inside the model. In case of non-sampling-based optimizers like DARTS, we can simply assign the sampled_alphas to be the same as the alphas.

Please validate that it works. Also see if there could be a better / more intuitive way of designing this.

Do NOT merge this PR. It was done in a rush as a proof-of-concept.