### PR TITLE
Add sigmoid activation to architectural parameters

### DIFF
--- a/src/confopt/oneshot/archsampler/base_sampler.py
+++ b/src/confopt/oneshot/archsampler/base_sampler.py
@@ -13,7 +13,7 @@ class BaseSampler(OneShotComponent):
         self,
         arch_parameters: list[torch.Tensor],
         sample_frequency: Literal["epoch", "step"],
-        post_sample_fn: Literal["default", "sigmoid"] = "default",
+        arch_combine_fn: Literal["default", "sigmoid"] = "default",
     ) -> None:
         super().__init__()
         self.arch_parameters = arch_parameters
@@ -24,7 +24,7 @@ class BaseSampler(OneShotComponent):
             "step",
         ], "sample_frequency must be either 'epoch' or 'step'"
         self.sample_frequency = sample_frequency
-        self.post_sample_fn = post_sample_fn
+        self.arch_combine_fn = arch_combine_fn
 
     @abstractmethod
     def sample_alphas(

--- a/src/confopt/oneshot/archsampler/darts/sampler.py
+++ b/src/confopt/oneshot/archsampler/darts/sampler.py
@@ -12,12 +12,12 @@ class DARTSSampler(BaseSampler):
         self,
         arch_parameters: list[torch.Tensor],
         sample_frequency: Literal["epoch", "step"] = "step",
-        post_sample_fn: Literal["default", "sigmoid"] = "default",
+        arch_combine_fn: Literal["default", "sigmoid"] = "default",
     ) -> None:
         super().__init__(
             arch_parameters=arch_parameters,
             sample_frequency=sample_frequency,
-            post_sample_fn=post_sample_fn,
+            arch_combine_fn=arch_combine_fn,
         )
 
     def sample_alphas(
@@ -25,9 +25,9 @@ class DARTSSampler(BaseSampler):
     ) -> list[torch.Tensor] | None:
         sampled_alphas = []
         for alpha in arch_parameters:
-            if self.post_sample_fn == "default":
+            if self.arch_combine_fn == "default":
                 sampled_alpha = torch.nn.functional.softmax(alpha, dim=-1)
-            elif self.post_sample_fn == "sigmoid":
+            elif self.arch_combine_fn == "sigmoid":
                 sampled_alpha = torch.nn.functional.sigmoid(alpha)
 
             sampled_alphas.append(sampled_alpha)

--- a/src/confopt/oneshot/archsampler/drnas/sampler.py
+++ b/src/confopt/oneshot/archsampler/drnas/sampler.py
@@ -13,12 +13,12 @@ class DRNASSampler(BaseSampler):
         self,
         arch_parameters: list[torch.Tensor],
         sample_frequency: Literal["epoch", "step"] = "step",
-        post_sample_fn: Literal["default", "sigmoid"] = "default",
+        arch_combine_fn: Literal["default", "sigmoid"] = "default",
     ) -> None:
         super().__init__(
             arch_parameters=arch_parameters,
             sample_frequency=sample_frequency,
-            post_sample_fn=post_sample_fn,
+            arch_combine_fn=arch_combine_fn,
         )
 
     def sample_alphas(self, arch_parameters: torch.Tensor) -> list[torch.Tensor]:
@@ -31,7 +31,7 @@ class DRNASSampler(BaseSampler):
         beta = F.elu(alpha) + 1
         weights = torch.distributions.dirichlet.Dirichlet(beta).rsample()
 
-        if self.post_sample_fn == "sigmoid":
+        if self.arch_combine_fn == "sigmoid":
             weights = torch.nn.functional.sigmoid(weights)
 
         return weights  # type: ignore

--- a/src/confopt/oneshot/archsampler/gdas/sampler.py
+++ b/src/confopt/oneshot/archsampler/gdas/sampler.py
@@ -15,12 +15,12 @@ class GDASSampler(BaseSampler):
         tau_min: float = 0.1,
         tau_max: float = 10,
         total_epochs: int = 250,
-        post_sample_fn: Literal["default"] = "default",
+        arch_combine_fn: Literal["default"] = "default",
     ) -> None:
         super().__init__(
             arch_parameters=arch_parameters,
             sample_frequency=sample_frequency,
-            post_sample_fn=post_sample_fn,
+            arch_combine_fn=arch_combine_fn,
         )
 
         self.tau_min = torch.Tensor([tau_min])

--- a/src/confopt/profiles/profile_config.py
+++ b/src/confopt/profiles/profile_config.py
@@ -23,7 +23,7 @@ class ProfileConfig:
         dropout: float | None = None,
         perturbation: str | None = None,
         perturbator_sample_frequency: str = "epoch",
-        sampler_post_sample_fn: str = "default",
+        sampler_arch_combine_fn: str = "default",
         entangle_op_weights: bool = False,
         lora_rank: int = 0,
         lora_warm_epochs: int = 0,
@@ -41,7 +41,7 @@ class ProfileConfig:
         self.lora_warm_epochs = lora_warm_epochs
         self.seed = seed
         self.searchspace_str = searchspace_str
-        self.sampler_post_sample_fn = sampler_post_sample_fn
+        self.sampler_arch_combine_fn = sampler_arch_combine_fn
         self._initialize_trainer_config()
         self._initialize_sampler_config()
         self._set_partial_connector(is_partial_connection)

--- a/src/confopt/profiles/profiles.py
+++ b/src/confopt/profiles/profiles.py
@@ -18,7 +18,7 @@ class DartsProfile(ProfileConfig, ABC):
         dropout: float | None = None,
         perturbation: str | None = None,
         sampler_sample_frequency: str = "step",
-        sampler_post_sample_fn: str = "default",
+        sampler_arch_combine_fn: str = "default",
         perturbator_sample_frequency: str = "epoch",
         partial_connector_config: dict | None = None,
         perturbator_config: dict | None = None,
@@ -43,7 +43,7 @@ class DartsProfile(ProfileConfig, ABC):
             dropout,
             perturbation,
             perturbator_sample_frequency,
-            sampler_post_sample_fn,
+            sampler_arch_combine_fn,
             entangle_op_weights,
             lora_rank,
             lora_warm_epochs,
@@ -67,7 +67,7 @@ class DartsProfile(ProfileConfig, ABC):
     def _initialize_sampler_config(self) -> None:
         darts_config = {
             "sample_frequency": self.sampler_sample_frequency,
-            "post_sample_fn": self.sampler_post_sample_fn,
+            "arch_combine_fn": self.sampler_arch_combine_fn,
         }
         self.sampler_config = darts_config  # type: ignore
 
@@ -80,7 +80,7 @@ class GDASProfile(ProfileConfig, ABC):
         dropout: float | None = None,
         perturbation: str | None = None,
         sampler_sample_frequency: str = "step",
-        sampler_post_sample_fn: str = "default",
+        sampler_arch_combine_fn: str = "default",
         perturbator_sample_frequency: str = "epoch",
         tau_min: float = 0.1,
         tau_max: float = 10,
@@ -109,7 +109,7 @@ class GDASProfile(ProfileConfig, ABC):
             dropout,
             perturbation,
             perturbator_sample_frequency,
-            sampler_post_sample_fn,
+            sampler_arch_combine_fn,
             entangle_op_weights,
             lora_rank,
             lora_warm_epochs,
@@ -133,7 +133,7 @@ class GDASProfile(ProfileConfig, ABC):
     def _initialize_sampler_config(self) -> None:
         gdas_config = {
             "sample_frequency": self.sampler_sample_frequency,
-            "post_sample_fn": self.sampler_post_sample_fn,
+            "arch_combine_fn": self.sampler_arch_combine_fn,
             "tau_min": self.tau_min,
             "tau_max": self.tau_max,
         }
@@ -148,7 +148,7 @@ class SNASProfile(ProfileConfig, ABC):
         dropout: float | None = None,
         perturbation: str | None = None,
         sampler_sample_frequency: str = "step",
-        sampler_post_sample_fn: str = "default",
+        sampler_arch_combine_fn: str = "default",
         perturbator_sample_frequency: str = "epoch",
         temp_init: float = 1.0,
         temp_min: float = 0.33,
@@ -181,7 +181,7 @@ class SNASProfile(ProfileConfig, ABC):
             dropout,
             perturbation,
             perturbator_sample_frequency,
-            sampler_post_sample_fn,
+            sampler_arch_combine_fn,
             entangle_op_weights,
             lora_rank,
             lora_warm_epochs,
@@ -205,7 +205,7 @@ class SNASProfile(ProfileConfig, ABC):
     def _initialize_sampler_config(self) -> None:
         snas_config = {
             "sample_frequency": self.sampler_sample_frequency,
-            "post_sample_fn": self.sampler_post_sample_fn,
+            "arch_combine_fn": self.sampler_arch_combine_fn,
             "temp_init": self.temp_init,
             "temp_min": self.temp_min,
             "temp_annealing": self.temp_annealing,
@@ -223,7 +223,7 @@ class DRNASProfile(ProfileConfig, ABC):
         perturbation: str | None = None,
         sampler_sample_frequency: str = "step",
         perturbator_sample_frequency: str = "epoch",
-        sampler_post_sample_fn: str = "default",
+        sampler_arch_combine_fn: str = "default",
         partial_connector_config: dict | None = None,
         perturbator_config: dict | None = None,
         entangle_op_weights: bool = False,
@@ -247,7 +247,7 @@ class DRNASProfile(ProfileConfig, ABC):
             dropout,
             perturbation,
             perturbator_sample_frequency,
-            sampler_post_sample_fn,
+            sampler_arch_combine_fn,
             entangle_op_weights,
             lora_rank,
             lora_warm_epochs,
@@ -271,7 +271,7 @@ class DRNASProfile(ProfileConfig, ABC):
     def _initialize_sampler_config(self) -> None:
         drnas_config = {
             "sample_frequency": self.sampler_sample_frequency,
-            "post_sample_fn": self.sampler_post_sample_fn,
+            "arch_combine_fn": self.sampler_arch_combine_fn,
         }
         self.sampler_config = drnas_config  # type: ignore
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -124,11 +124,11 @@ class TestDartsProfile(unittest.TestCase):
 
     def test_sampler_post_fn(self) -> None:
         profile = DartsProfile(epochs=1)
-        assert profile.sampler_config["post_sample_fn"] == "default"
-        sampler_config = {"post_sample_fn": "sigmoid"}
+        assert profile.sampler_config["arch_combine_fn"] == "default"
+        sampler_config = {"arch_combine_fn": "sigmoid"}
         profile.configure_sampler(**sampler_config)
         assert (
-            profile.sampler_config["post_sample_fn"] == sampler_config["post_sample_fn"]
+            profile.sampler_config["arch_combine_fn"] == sampler_config["arch_combine_fn"]
         )
 
 
@@ -184,11 +184,11 @@ class TestDRNASProfile(unittest.TestCase):
 
     def test_sampler_post_fn(self) -> None:
         profile = DRNASProfile(epochs=1)
-        assert profile.sampler_config["post_sample_fn"] == "default"
-        sampler_config = {"post_sample_fn": "sigmoid"}
+        assert profile.sampler_config["arch_combine_fn"] == "default"
+        sampler_config = {"arch_combine_fn": "sigmoid"}
         profile.configure_sampler(**sampler_config)
         assert (
-            profile.sampler_config["post_sample_fn"] == sampler_config["post_sample_fn"]
+            profile.sampler_config["arch_combine_fn"] == sampler_config["arch_combine_fn"]
         )
 
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -4,14 +4,14 @@ import torch
 from confopt.oneshot.archsampler import DARTSSampler, GDASSampler, DRNASSampler, BaseSampler
 
 
-def _test_post_sample_fn_default(sampler: BaseSampler, alphas: list[torch.Tensor]) -> None:
+def _test_arch_combine_fn_default(sampler: BaseSampler, alphas: list[torch.Tensor]) -> None:
     alphas_normal, alphas_reduction = sampler.sample_alphas(alphas)
 
     assert torch.allclose(alphas_normal.sum(dim=-1), torch.ones((14,)))
     assert torch.allclose(alphas_reduction.sum(dim=-1), torch.ones((14,)))
 
 
-def _test_post_sample_fn_sigmoid(sampler: BaseSampler, alphas: list[torch.Tensor]) -> None:
+def _test_arch_combine_fn_sigmoid(sampler: BaseSampler, alphas: list[torch.Tensor]) -> None:
     alphas_normal, alphas_reduction = sampler.sample_alphas(alphas)
 
     assert not torch.allclose(alphas_normal.sum(dim=-1), torch.ones((14,)))
@@ -22,16 +22,16 @@ class TestDARTSSampler(unittest.TestCase):
     def test_post_sample_fn_default(self) -> None:
         alphas = [torch.randn(14, 8), torch.randn(14, 8)]
         sampler = DARTSSampler(
-            alphas, sample_frequency="epoch", post_sample_fn="default"
+            alphas, sample_frequency="epoch", arch_combine_fn="default"
         )
-        _test_post_sample_fn_default(sampler, alphas)
+        _test_arch_combine_fn_default(sampler, alphas)
 
     def test_post_sample_fn_sigmoid(self) -> None:
         alphas = [torch.randn(14, 8), torch.randn(14, 8)]
         sampler = DARTSSampler(
-            alphas, sample_frequency="epoch", post_sample_fn="sigmoid"
+            alphas, sample_frequency="epoch", arch_combine_fn="sigmoid"
         )
-        _test_post_sample_fn_sigmoid(sampler, alphas)
+        _test_arch_combine_fn_sigmoid(sampler, alphas)
         alphas_normal, alphas_reduction = sampler.sample_alphas(alphas)
         assert torch.allclose(alphas_normal, torch.nn.functional.sigmoid(alphas[0]))
         assert torch.allclose(alphas_reduction, torch.nn.functional.sigmoid(alphas[1]))
@@ -41,35 +41,35 @@ class TestDRNASSampler(unittest.TestCase):
     def test_post_sample_fn_default(self) -> None:
         alphas = [torch.randn(14, 8), torch.randn(14, 8)]
         sampler = DRNASSampler(
-            alphas, sample_frequency="epoch", post_sample_fn="default"
+            alphas, sample_frequency="epoch", arch_combine_fn="default"
         )
-        _test_post_sample_fn_default(sampler, alphas)
+        _test_arch_combine_fn_default(sampler, alphas)
 
     def test_post_sample_fn_sigmoid(self) -> None:
         alphas = [torch.randn(14, 8), torch.randn(14, 8)]
         sampler = DRNASSampler(
-            alphas, sample_frequency="epoch", post_sample_fn="sigmoid"
+            alphas, sample_frequency="epoch", arch_combine_fn="sigmoid"
         )
-        _test_post_sample_fn_sigmoid(sampler, alphas)
+        _test_arch_combine_fn_sigmoid(sampler, alphas)
 
 
 class TestGDASSampler(unittest.TestCase):
     def test_post_sample_fn_default(self) -> None:
         alphas = [torch.randn(14, 8), torch.randn(14, 8)]
         sampler = GDASSampler(
-            alphas, sample_frequency="epoch", post_sample_fn="default"
+            alphas, sample_frequency="epoch", arch_combine_fn="default"
         )
-        _test_post_sample_fn_default(sampler, alphas)
+        _test_arch_combine_fn_default(sampler, alphas)
 
     def test_post_sample_fn_sigmoid(self) -> None:
         alphas = [torch.randn(14, 8), torch.randn(14, 8)]
         sampler = GDASSampler(
-            alphas, sample_frequency="epoch", post_sample_fn="sigmoid"
+            alphas, sample_frequency="epoch", arch_combine_fn="sigmoid"
         )
-        # GDAS must ignore the "sigmoid" post_sample_fn since it respecting it
+        # GDAS must ignore the "sigmoid" arch_combine_fn since it respecting it
         # wouldn't really make a difference, considering that only one operation
         # is chosen per edge
-        _test_post_sample_fn_default(sampler, alphas)
+        _test_arch_combine_fn_default(sampler, alphas)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As prescribed in [FairDARTS](https://github.com/xiaomi-automl/FairDARTS), this PR adds the functionality to use sigmoid instead of softmax as the activation to help the architectural values learn without "competing" with one another. Here is how the beahviours of optimizers are affected:

1. DARTS - uses sigmoid instead of softmax.
2. DrNAS - uses sigmoid activation _after_ sampling from the dirichlet distribution
3. GDAS - no change in behaviour, since it has to pick one operation per edge. Replacing the softmax in `probs = torch.nn.functional.softmax(logits, dim=-1)` with sigmoid might seem like an option, but it is unlikely to make a difference, since it simply picks the operation with the highest value (and that would no change, even with sigmoid)

FairDARTS also employs a penalty term to the loss to force the architectural values to either 1 or 0. This is absent in the PR and will have to be implemented separately in another PR for regularization terms.