### PR TITLE
Refactor base SearchSpace

### DIFF
--- a/src/confopt/searchspace/common/base_search.py
+++ b/src/confopt/searchspace/common/base_search.py
@@ -68,6 +68,34 @@ class SearchSpace(ModelWrapper):
         for component in self.components:
             component.new_step()
 
+    def get_num_ops(self) -> int:
+        """Get number of operations in an edge of a cell of the model.
+
+        Returns:
+            int: Number of operations
+        """
+        raise NotImplementedError("get_num_ops is not implemented for this searchpace")
+
+    def get_num_edges(self) -> int:
+        """Get number of edges in a cell of the model.
+
+        Returns:
+            int: Number of edges
+        """
+        raise NotImplementedError(
+            "get_num_edges is not implemented for this searchpace"
+        )
+
+    def get_num_nodes(self) -> int:
+        """Get number of nodes in a cell of the model.
+
+        Returns:
+            int: Number of nodes
+        """
+        raise NotImplementedError(
+            "get_num_nodes is not implemented for this searchpace"
+        )
+
 
 class ArchAttentionSupport(ModelWrapper):
     def set_arch_attention(self, enabled: bool) -> None:
@@ -162,30 +190,6 @@ class OperationStatisticsSupport(ModelWrapper):
         # all_stats.update(other_stats) # Add other stats here
 
         return all_stats
-
-    @abstractmethod
-    def get_num_ops(self) -> int:
-        """Get number of operations in an edge of a cell of the model.
-
-        Returns:
-            int: Number of operations
-        """
-
-    @abstractmethod
-    def get_num_edges(self) -> int:
-        """Get number of edges in a cell of the model.
-
-        Returns:
-            int: Number of rdges
-        """
-
-    @abstractmethod
-    def get_num_nodes(self) -> int:
-        """Get number of nodes in a cell of the model.
-
-        Returns:
-            int: Number of nodes
-        """
 
 
 class PerturbationArchSelectionSupport(ModelWrapper):

--- a/src/confopt/train/projection.py
+++ b/src/confopt/train/projection.py
@@ -9,7 +9,6 @@ import torch.utils
 from confopt.oneshot.archsampler.darts.sampler import DARTSSampler
 from confopt.searchspace import SearchSpace
 from confopt.searchspace.common.base_search import (
-    OperationStatisticsSupport,
     PerturbationArchSelectionSupport,
 )
 from confopt.train import ConfigurableTrainer, SearchSpaceHandler
@@ -170,7 +169,7 @@ class PerturbationArchSelection:
 
         assert isinstance(
             unwrapped_network,
-            (PerturbationArchSelectionSupport, OperationStatisticsSupport),
+            PerturbationArchSelectionSupport,
         )
 
         train_queue, valid_queue, _ = self.trainer.data.get_dataloaders(


### PR DESCRIPTION
- `get_num_ops`, `get_num_edges`, and `get_num_nodes` were part of `OperationStatisticsSupport` class.
- They have now been moved to the base `SearchSpace`.