### PR TITLE
refactor: remove default values for epochs and search space in Profiles

### DIFF
--- a/src/confopt/profiles/profile_config.py
+++ b/src/confopt/profiles/profile_config.py
@@ -19,6 +19,7 @@ class BaseProfile:
     def __init__(
         self,
         config_type: str,
+        searchspace_str: str,
         epochs: int = 50,
         *,
         sampler_sample_frequency: str = "step",
@@ -35,7 +36,6 @@ class BaseProfile:
         lora_toggle_epochs: list[int] | None = None,
         lora_toggle_probability: float | None = None,
         seed: int = 100,
-        searchspace_str: str = "nb201",
         oles: bool = False,
         calc_gm_score: bool = False,
         prune_epochs: list[int] | None = None,
@@ -45,6 +45,13 @@ class BaseProfile:
         regularization_config: dict | None = None,
         pt_select_architecture: bool = False,
     ) -> None:
+        assert searchspace_str in [
+            "nb201",
+            "darts",
+            "nb1shot1",
+            "tnb101",
+        ], f"Invalid searchspace {searchspace_str}!"
+        self.searchspace_str = searchspace_str
         self.config_type = config_type
         self.epochs = epochs
         self.sampler_sample_frequency = (
@@ -52,7 +59,6 @@ class BaseProfile:
         )
         self.lora_warm_epochs = lora_warm_epochs
         self.seed = seed
-        self.searchspace_str = searchspace_str
         self.sampler_arch_combine_fn = sampler_arch_combine_fn
         self._initialize_trainer_config()
         self._initialize_sampler_config()

--- a/src/confopt/profiles/profiles.py
+++ b/src/confopt/profiles/profiles.py
@@ -14,6 +14,7 @@ Genotype = namedtuple("Genotype", "normal normal_concat reduce reduce_concat")
 class DARTSProfile(BaseProfile, ABC):
     def __init__(
         self,
+        searchspace_str: str,
         epochs: int,
         **kwargs: Any,
     ) -> None:
@@ -21,6 +22,7 @@ class DARTSProfile(BaseProfile, ABC):
 
         super().__init__(
             PROFILE_TYPE,
+            searchspace_str,
             epochs,
             **kwargs,
         )
@@ -39,7 +41,8 @@ class GDASProfile(BaseProfile, ABC):
 
     def __init__(
         self,
-        epochs: int = 240,
+        searchspace_str: str,
+        epochs: int,
         tau_min: float = 0.1,
         tau_max: float = 10,
         **kwargs: Any,
@@ -49,6 +52,7 @@ class GDASProfile(BaseProfile, ABC):
 
         super().__init__(
             self.PROFILE_TYPE,
+            searchspace_str,
             epochs,
             **kwargs,
         )
@@ -85,7 +89,8 @@ class ReinMaxProfile(GDASProfile):
 class SNASProfile(BaseProfile, ABC):
     def __init__(
         self,
-        epochs: int = 150,
+        searchspace_str: str,
+        epochs: int,
         temp_init: float = 1.0,
         temp_min: float = 0.03,
         temp_annealing: bool = True,
@@ -99,6 +104,7 @@ class SNASProfile(BaseProfile, ABC):
 
         super().__init__(  # type: ignore
             PROFILE_TYPE,
+            searchspace_str,
             epochs,
             **kwargs,
         )
@@ -119,13 +125,15 @@ class SNASProfile(BaseProfile, ABC):
 class DRNASProfile(BaseProfile, ABC):
     def __init__(
         self,
-        epochs: int = 100,
+        searchspace_str: str,
+        epochs: int,
         **kwargs: Any,
     ) -> None:
         PROFILE_TYPE = "DRNAS"
 
         super().__init__(  # type: ignore
             PROFILE_TYPE,
+            searchspace_str,
             epochs,
             **kwargs,
         )

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -58,6 +58,7 @@ class TestBaseProfile(unittest.TestCase):
     def test_invalid_configuration(self) -> None:
         profile = BaseProfile(
             "TEST",
+            searchspace_str="nb201",
             epochs=1,
             is_partial_connection=True,
             dropout=0.5,
@@ -133,6 +134,7 @@ class TestDartsProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = DARTSProfile(  # noqa: F841
                 epochs=100,
+                searchspace_str="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -143,6 +145,7 @@ class TestDartsProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = DARTSProfile(
             epochs=100,
+            searchspace_str="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"sample_frequency": "epoch"}
@@ -156,7 +159,7 @@ class TestDartsProfile(unittest.TestCase):
             profile.configure_sampler(invalid_config="step")
 
     def test_sampler_post_fn(self) -> None:
-        profile = DARTSProfile(epochs=1)
+        profile = DARTSProfile(epochs=1, searchspace_str="nb201")
         assert profile.sampler_config["arch_combine_fn"] == "default"
         sampler_config = {"arch_combine_fn": "sigmoid"}
         profile.configure_sampler(**sampler_config)
@@ -210,6 +213,7 @@ class TestDRNASProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = DRNASProfile(  # noqa: F841
                 epochs=100,
+                searchspace_str="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -220,6 +224,7 @@ class TestDRNASProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = DRNASProfile(
             epochs=100,
+            searchspace_str="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"sample_frequency": "epoch"}
@@ -233,7 +238,7 @@ class TestDRNASProfile(unittest.TestCase):
             profile.configure_sampler(invalid_config="step")
 
     def test_sampler_post_fn(self) -> None:
-        profile = DRNASProfile(epochs=1)
+        profile = DRNASProfile(epochs=1, searchspace_str="nb201",)
         assert profile.sampler_config["arch_combine_fn"] == "default"
         sampler_config = {"arch_combine_fn": "sigmoid"}
         profile.configure_sampler(**sampler_config)
@@ -289,6 +294,7 @@ class TestGDASProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = GDASProfile(  # noqa: F841
                 epochs=100,
+                searchspace_str="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -299,6 +305,7 @@ class TestGDASProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = GDASProfile(
             epochs=100,
+            searchspace_str="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"tau_max": 12, "tau_min": 0.3}
@@ -359,6 +366,7 @@ class TestSNASProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = SNASProfile(  # noqa: F841
                 epochs=100,
+                searchspace_str="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -369,6 +377,7 @@ class TestSNASProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = SNASProfile(
             epochs=100,
+            searchspace_str="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"temp_min": 0.5, "temp_init": 1.3}


### PR DESCRIPTION
The default value of searchspace_str was "nb201", and this caused the trainer to load the nb201 configurations when a search space was not specified. To avoid this issue, the search space string and the number of epochs of training the supernet no longer have default values,.