### PR TITLE
feat(genotypes): add mask to the genotypes

### DIFF
--- a/src/confopt/searchspace/nb1_shot_1/core/model_search.py
+++ b/src/confopt/searchspace/nb1_shot_1/core/model_search.py
@@ -521,7 +521,12 @@ class Network(nn.Module):
         else:
             alphas_mixed_op = self.arch_parameters()[0]
 
-        chosen_node_ops = softmax(alphas_mixed_op, axis=-1).argmax(-1)
+        alphas_mixed_op = softmax(alphas_mixed_op, axis=-1)
+
+        if self.mask is not None:
+            alphas_mixed_op = normalize_params(alphas_mixed_op, self.mask)
+
+        chosen_node_ops = alphas_mixed_op.argmax(-1)
 
         node_list = [PRIMITIVES[i] for i in chosen_node_ops]
         alphas_output = self.arch_parameters()[1]

--- a/src/confopt/searchspace/nb201/core/model_search.py
+++ b/src/confopt/searchspace/nb201/core/model_search.py
@@ -249,6 +249,11 @@ class NB201SearchModel(nn.Module):
         else:
             arch_parameters = self.arch_parameters
 
+        arch_parameters = torch.softmax(arch_parameters, dim=-1)
+
+        if self.mask is not None:
+            arch_parameters = normalize_params(arch_parameters, self.mask)
+
         for i in range(1, self.max_nodes):
             xlist = []
             for j in range(i):

--- a/src/confopt/searchspace/tnb101/core/model_search.py
+++ b/src/confopt/searchspace/tnb101/core/model_search.py
@@ -339,6 +339,12 @@ class TNB101SearchModel(nn.Module):
             arch_parameters = self._compute_arch_attention(self._arch_parameters)
         else:
             arch_parameters = self._arch_parameters
+
+        arch_parameters = torch.softmax(arch_parameters, dim=-1)
+
+        if self.mask is not None:
+            arch_parameters = normalize_params(arch_parameters, self.mask)
+
         edge2index = self.cells[0].edge2index
 
         for i in range(1, self.max_nodes):


### PR DESCRIPTION
Genotypes did not include the mask while calculating argmax. This PR applies softmax (where there were not any) and then applies mask (for removing pruned operation) from the arch parameters. 