### PR TITLE
fix(_init_experiment_state): loading now initializes lora

### DIFF
--- a/src/confopt/train/experiment.py
+++ b/src/confopt/train/experiment.py
@@ -963,7 +963,9 @@ class Experiment:
 
         # Load from supernet
         if model_source == "supernet":
-            trainer._init_experiment_state(setup_new_run=False)
+            trainer._init_experiment_state(
+                search_space_handler=search_space_handler, setup_new_run=False
+            )
 
             # reroute logger
             self.logger = Logger(


### PR DESCRIPTION
The model could not be loaded due to missing keys:
 - lora layers were required to be initalized. 
 - The flop parameters were also missing during initialization, thus a dummy forward pass was done to add them back.
