### PR TITLE
fix: fix layer alignment when there is only one cell of a kind

### DIFF
--- a/src/confopt/searchspace/darts/core/model_search.py
+++ b/src/confopt/searchspace/darts/core/model_search.py
@@ -651,7 +651,11 @@ class Network(nn.Module):
         self, only_first_and_last: bool = False
     ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
         def get_grads(alphas_grads_list: list[torch.Tensor]) -> list[torch.Tensor]:
+            if len(alphas_grads_list) < 2:
+                return []
+
             grads = []
+
             if only_first_and_last:
                 grads.append(alphas_grads_list[0].reshape(-1))
                 grads.append(alphas_grads_list[-1].reshape(-1))

--- a/src/confopt/utils/__init__.py
+++ b/src/confopt/utils/__init__.py
@@ -165,6 +165,9 @@ def clear_grad_cosine(m: torch.nn.Module) -> None:
 
 
 def calc_layer_alignment_score(layer_gradients: list[torch.Tensor]) -> float:
+    if len(layer_gradients) < 2:
+        return float("nan")
+
     scale = len(layer_gradients) * (len(layer_gradients) - 1) / 2
     score = 0
     for i in range(len(layer_gradients)):


### PR DESCRIPTION
Layer alignment computation crashes when there is only one cell of a certain kind. This PR fixes that.
