### PR TITLE
feat: split CIFAR data into supernet and discrete model portionis

### DIFF
--- a/src/confopt/dataset/__init__.py
+++ b/src/confopt/dataset/__init__.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import Any, Type, Union
 
 from confopt.enums import DatasetType
 
@@ -29,6 +29,7 @@ def get_dataset(
     cutout: int,
     cutout_length: int,
     train_portion: float = 1.0,
+    **kwargs: Any,
 ) -> AbstractData:
     dataset_cls: Type[AbstractData] = CIFAR10Data
     if dataset == DatasetType.CIFAR10:
@@ -52,6 +53,7 @@ def get_dataset(
         cutout=cutout,
         cutout_length=cutout_length,
         train_portion=train_portion,
+        **kwargs,
     )
 
 

--- a/src/confopt/train/experiment.py
+++ b/src/confopt/train/experiment.py
@@ -596,8 +596,7 @@ class Experiment:
         cutout: int,
         cutout_length: int,
         train_portion: float,
-        *args: Any,  # noqa: ARG002
-        **kwargs: Any,  # noqa: ARG002
+        **kwargs: Any,
     ) -> AbstractData:
         return get_dataset(
             dataset=self.dataset,
@@ -606,6 +605,7 @@ class Experiment:
             cutout=cutout,  # type: ignore
             cutout_length=cutout_length,  # type: ignore
             train_portion=train_portion,  # type: ignore
+            **kwargs,
         )
 
     # refactor the name to train
@@ -679,6 +679,7 @@ class Experiment:
             cutout=trainer_arguments.cutout,  # type: ignore
             cutout_length=trainer_arguments.cutout_length,  # type: ignore
             train_portion=trainer_arguments.train_portion,  # type: ignore
+            is_supernet_portion=False,
         )
 
         w_optimizer = self._get_optimizer(trainer_arguments.optim)(  # type: ignore


### PR DESCRIPTION
This PR splits the CIFAR dataset into two portions: the supernet training portion and the discrete model training portion. What it means is that effectively, the supernet training is done on one split of the data, and the model is trained on another split. The models do not see the full dataset during training.

The performance of the models on the "discrete model training split" is therefore an unbiased estimate of how good the architectures are because architectures which might overfit on the "supernet training split" are not rewarded.