### PR TITLE
feat(data): add new splits of CIFAR10 dataset as different classes

### DIFF
--- a/src/confopt/dataset/__init__.py
+++ b/src/confopt/dataset/__init__.py
@@ -5,6 +5,8 @@ from confopt.enums import DatasetType
 from .data import (
     AbstractData,
     CIFAR10Data,
+    CIFAR10DiscreteDataset,
+    CIFAR10SupernetDataset,
     CIFAR100Data,
     FGVCAircraftDataset,
     ImageNet16Data,
@@ -33,6 +35,10 @@ def get_dataset(
     dataset_cls: Type[AbstractData] = CIFAR10Data
     if dataset == DatasetType.CIFAR10:
         dataset_cls = CIFAR10Data
+    elif dataset == DatasetType.CIFAR10_SUPERNET:
+        dataset_cls = CIFAR10SupernetDataset
+    elif dataset == DatasetType.CIFAR10_MODEL:
+        dataset_cls = CIFAR10DiscreteDataset
     elif dataset == DatasetType.CIFAR100:
         dataset_cls = CIFAR100Data
     elif dataset == DatasetType.IMGNET16:

--- a/src/confopt/dataset/data.py
+++ b/src/confopt/dataset/data.py
@@ -303,6 +303,67 @@ class CIFAR100Data(CIFARData):
         return train_data, test_data
 
 
+class CIFAR10SupernetDataset(CIFAR10Data):
+    def build_datasets(self) -> tuple[DS, DS, DS]:
+        train_transform, test_transform = self.get_transforms()
+        train_data, test_data = self.load_datasets(
+            self.root, train_transform, test_transform
+        )
+
+        num_train = len(train_data) // 2  # type: ignore
+        print("Warning: Using only half of the CIFAR training data!")
+
+        indices = list(range(num_train))
+
+        split = int(np.floor(self.train_portion * num_train))
+        train_start_idx = 0
+        train_end_idx = split
+        val_start_idx = split
+        val_end_idx = num_train
+
+        train_sampler = torch.utils.data.sampler.SubsetRandomSampler(
+            indices[train_start_idx:train_end_idx]
+        )
+        val_sampler = torch.utils.data.sampler.SubsetRandomSampler(
+            indices[val_start_idx:val_end_idx]
+        )
+        return (
+            (train_data, train_sampler),
+            (train_data, val_sampler),
+            (test_data, None),
+        )
+
+
+class CIFAR10DiscreteDataset(CIFAR10Data):
+    def build_datasets(self) -> tuple[DS, DS, DS]:
+        train_transform, test_transform = self.get_transforms()
+        train_data, test_data = self.load_datasets(
+            self.root, train_transform, test_transform
+        )
+
+        num_train = len(train_data) // 2  # type: ignore
+        print("Warning: Using only half of the CIFAR training data!")
+
+        indices = list(range(num_train))
+
+        train_start_idx = num_train
+        train_end_idx = -1
+        val_start_idx = 0
+        val_end_idx = num_train
+
+        train_sampler = torch.utils.data.sampler.SubsetRandomSampler(
+            indices[train_start_idx:train_end_idx]
+        )
+        val_sampler = torch.utils.data.sampler.SubsetRandomSampler(
+            indices[val_start_idx:val_end_idx]
+        )
+        return (
+            (train_data, train_sampler),
+            (train_data, val_sampler),
+            (test_data, None),
+        )
+
+
 class ImageNet16Data(ImageNetData):
     def __init__(
         self, root: str, cutout: int, cutout_length: int, train_portion: float = 1.0

--- a/src/confopt/enums.py
+++ b/src/confopt/enums.py
@@ -37,6 +37,8 @@ class PerturbatorType(Enum):
 
 class DatasetType(Enum):
     CIFAR10 = "cifar10"
+    CIFAR10_SUPERNET = "cifar10_supernet"
+    CIFAR10_MODEL = "cifar10_model"
     CIFAR100 = "cifar100"
     IMGNET16 = "imgnet16"
     IMGNET16_120 = "imgnet16_120"

--- a/src/confopt/train/experiment.py
+++ b/src/confopt/train/experiment.py
@@ -517,6 +517,8 @@ class Experiment:
             searchspace_config["genotype"] = eval(genotype_str)
             if self.dataset in (
                 DatasetType.CIFAR10,
+                DatasetType.CIFAR10_MODEL,
+                DatasetType.CIFAR10_SUPERNET,
                 DatasetType.CIFAR100,
                 DatasetType.AIRCRAFT,
             ):

--- a/src/confopt/utils/__init__.py
+++ b/src/confopt/utils/__init__.py
@@ -7,6 +7,8 @@ from typing import Iterable, Literal
 import torch
 from torch import nn
 
+from confopt.enums import DatasetType
+
 from .checkpoints import (
     copy_checkpoint,
     save_checkpoint,
@@ -118,19 +120,23 @@ def drop_path(x: torch.Tensor, drop_prob: float) -> torch.Tensor:
 
 
 def get_num_classes(dataset: str, domain: str | None = None) -> int:
-    if dataset == "cifar10":
+    if dataset in (
+        DatasetType.CIFAR10.value,
+        DatasetType.CIFAR10_MODEL.value,
+        DatasetType.CIFAR10_SUPERNET.value,
+    ):
         num_classes = 10
-    elif dataset == "cifar100":
+    elif dataset == DatasetType.CIFAR100.value:
         num_classes = 100
-    elif dataset in ("imgnet16_120", "imgnet16"):
+    elif dataset in (DatasetType.IMGNET16_120.value, DatasetType.IMGNET16.value):
         num_classes = 120
-    elif dataset == "taskonomy":
+    elif dataset == DatasetType.TASKONOMY.value:
         assert domain in ["class_object", "class_scene"]
         if "class_object" in domain:
             num_classes = 75
         elif "class_scene" in domain:
             num_classes = 47
-    elif dataset == "aircraft":
+    elif dataset == DatasetType.AIRCRAFT.value:
         num_classes = 30
     else:
         raise ValueError("dataset is not defined.")


### PR DESCRIPTION
This PR introduces new splits of the CIFAR10 Datasets as separate dataset classes, allowing us to train the supernet on one partition and train the discrete on the other split.