### PR TITLE
Refactor profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ We define modular, differentiable NAS components within our library. Below is a 
 ```python 
 from confopt.profile import DARTSProfile
 from confopt.train import Experiment
-from confopt.enums import SearchSpaceType, DatasetType
+from confopt.enums import TrainerPresetType, SearchSpaceType, DatasetType
 
 profile = DARTSProfile(
-        searchspace_type=SearchSpaceType.DARTS,
+        trainer_preset=TrainerPresetType.DARTS,
         epochs=3
 )
 

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -53,10 +53,10 @@ Below is a snippet that demonstrates how we run a vanilla-DARTS experiment.
 ```python 
 from confopt.profile import DARTSProfile
 from confopt.train import Experiment
-from confopt.enums import SearchSpaceType, DatasetType
+from confopt.enums import TrainerPresetType, SearchSpaceType, DatasetType
 
 profile = DARTSProfile(
-        searchspace_type=SearchSpaceType.DARTS,
+        trainer_preset=TrainerPresetType.DARTS,
         epochs=3
 )
 

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from confopt.profile import DARTSProfile, DRNASProfile, GDASProfile, ReinMaxProfile
 from confopt.train import Experiment
-from confopt.enums import DatasetType, SearchSpaceType
+from confopt.enums import DatasetType, TrainerPresetType, SearchSpaceType
 
 if __name__ == "__main__":
     searchspace = SearchSpaceType.DARTS
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     }
 
     profile = DRNASProfile(
-        searchspace_type=searchspace,
+        trainer_preset=TrainerPresetType.DARTS,
         epochs=10,
         oles=True,
         calc_gm_score=True,

--- a/examples/demo_advanced.py
+++ b/examples/demo_advanced.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from confopt.profile import GDASProfile
 from confopt.train import Experiment
-from confopt.enums import DatasetType, SearchSpaceType
+from confopt.enums import DatasetType, TrainerPresetType, SearchSpaceType
 
 if __name__ == "__main__":
     search_space = SearchSpaceType.DARTS
 
     profile = GDASProfile(
-        searchspace_type=search_space,
+        trainer_preset=TrainerPresetType.DARTS,
         epochs=10,
         perturbation="random",
         entangle_op_weights=True,

--- a/examples/demo_light.py
+++ b/examples/demo_light.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from confopt.profile import GDASProfile
 from confopt.train import Experiment
-from confopt.enums import SearchSpaceType, DatasetType
+from confopt.enums import SearchSpaceType, TrainerPresetType, DatasetType
 
 if __name__ == "__main__":
     profile = GDASProfile(
-        searchspace_type=SearchSpaceType.DARTS,
+        trainer_preset=TrainerPresetType.DARTS,
         epochs=3,
     )
 

--- a/examples/demo_taskonomy.py
+++ b/examples/demo_taskonomy.py
@@ -8,7 +8,7 @@ from confopt.utils import get_num_classes
 if __name__ == "__main__":
     domain = "class_object"
     profile = GDASProfile(
-        searchspace_type="tnb101", epochs=3, searchspace_domain=domain
+        trainer_preset="tnb101", epochs=3, searchspace_domain=domain
     )
     profile.configure_searchspace(num_classes=get_num_classes("taskonomy", domain))
     experiment = Experiment(

--- a/examples/example_synthetic.py
+++ b/examples/example_synthetic.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     searchspace = SearchSpaceType.BABYDARTS
     dataset = DatasetType.SYNTHETIC
 
-    profile = get_profile(args)(searchspace_type=searchspace, epochs=args.search_epochs)
+    profile = get_profile(args)(trainer_preset=searchspace.value, epochs=args.search_epochs)
 
     profile.configure_synthetic_dataset(
         signal_width=args.signal_width,

--- a/examples/examples_lora.py
+++ b/examples/examples_lora.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     seed = 100
 
     profile = DARTSProfile(
-        searchspace_type=searchspace,
+        trainer_preset="darts",
         is_partial_connection=True,
         perturbation="random",
         sampler_sample_frequency="step",

--- a/examples/experiment_drnas.py
+++ b/examples/experiment_drnas.py
@@ -7,7 +7,7 @@ import wandb
 
 from confopt.profile import DiscreteProfile, DRNASProfile
 from confopt.train import Experiment
-from confopt.enums import DatasetType, SearchSpaceType
+from confopt.enums import DatasetType, SearchSpaceType, TrainerPresetType
 
 dataset_size = {
     "cifar10": 10,
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
     # Sampler and Perturbator have different sample_frequency
     profile = DRNASProfile(
-        searchspace_type=searchspace,
+        trainer_preset=TrainerPresetType(args.searchspace),
         is_partial_connection=args.searchspace == "darts",
         epochs=args.search_epochs,
         sampler_sample_frequency="step",
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     }
     profile.configure_trainer(**train_config)
     discrete_profile = DiscreteProfile(
-        searchspace_type=searchspace, epochs=args.eval_epochs, train_portion=0.9
+        trainer_preset=args.searchspace, epochs=args.eval_epochs, train_portion=0.9
     )
     discrete_profile.configure_trainer(batch_size=64)
 

--- a/examples/experiment_example.py
+++ b/examples/experiment_example.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from confopt.profile import GDASProfile
 from confopt.train import Experiment
-from confopt.enums import DatasetType, SearchSpaceType
+from confopt.enums import DatasetType, SearchSpaceType, TrainerPresetType
 
 if __name__ == "__main__":
     searchspace = SearchSpaceType("nb201")
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 
     # Sampler and Perturbator have different sample_frequency
     profile = GDASProfile(
-        searchspace_type=searchspace,
+        trainer_preset=TrainerPresetType("nb201"),
         is_partial_connection=True,
         perturbation="random",
         sampler_sample_frequency="step",

--- a/examples/notebooks/demo_notebook.ipynb
+++ b/examples/notebooks/demo_notebook.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "from confopt.profile import DARTSProfile\n",
     "from confopt.train import Experiment\n",
-    "from confopt.enums import SearchSpaceType, DatasetType"
+    "from confopt.enums import SearchSpaceType, DatasetType, TrainerPresetType"
    ]
   },
   {
@@ -51,7 +51,7 @@
    "outputs": [],
    "source": [
     "profile = DARTSProfile(\n",
-    "    searchspace_type=SearchSpaceType.DARTS,\n",
+    "    trainer_preset=TrainerPresetType.DARTS,\n",
     "    epochs=3,\n",
     "    seed=100,\n",
     "    is_partial_connection=True,\n",
@@ -115,7 +115,7 @@
     "from confopt.profile import GDASProfile\n",
     "\n",
     "profile = GDASProfile(\n",
-    "    searchspace_type=SearchSpaceType.NB201,\n",
+    "    trainer_preset=TrainerPresetType.NB201,\n",
     "    epochs=10,\n",
     "    perturbation=\"random\",\n",
     "    lora_rank=1,\n",
@@ -323,7 +323,7 @@
     "from confopt.profile import DiscreteProfile\n",
     "\n",
     "discrete_profile = DiscreteProfile(\n",
-    "    searchspace_type=SearchSpaceType.DARTS,\n",
+    "    trainer_preset=TrainerPresetType.DARTS,\n",
     "    epochs=10,\n",
     "    seed=100,\n",
     "    batch_size=96,\n",

--- a/scripts/benchsuite_experiments/benchsuite.py
+++ b/scripts/benchsuite_experiments/benchsuite.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from confopt.enums import DatasetType, SearchSpaceType
+from confopt.enums import DatasetType, SearchSpaceType, TrainerPresetType
 from confopt.profile import BaseProfile, DARTSProfile, DiscreteProfile
 from confopt.searchspace.darts.core.genotypes import PRIMITIVES
 from confopt.train import Experiment
@@ -180,7 +180,7 @@ def configure_discrete_profile_with_hp_set(
 
 if __name__ == "__main__":
     profile = DARTSProfile(
-        searchspace_type=SearchSpaceType.DARTS,
+        trainer_preset=TrainerPresetType.DARTS,
         epochs=10,
     )
 

--- a/scripts/benchsuite_experiments/supernet_search.py
+++ b/scripts/benchsuite_experiments/supernet_search.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
 
     epochs = 3 if args.dryrun is True else epochs_profiles[args.optimizer]
     profile = profile_classes[args.optimizer](
-        searchspace_type=SEARCHSPACE,
+        trainer_preset=SEARCHSPACE.value,
         epochs=epochs,
         is_partial_connection=args.pcdarts,
         perturbation=args.sdarts,

--- a/scripts/benchsuite_experiments/train_genotype.py
+++ b/scripts/benchsuite_experiments/train_genotype.py
@@ -108,7 +108,7 @@ def set_profile_genotype(discrete_profile: DiscreteProfile, path: str) -> None:
 def main(args: argparse.Namespace, hpset: int) -> None:
 
     discrete_profile = DiscreteProfile(
-        searchspace_type="darts",
+        trainer_preset="darts",
         epochs=args.epochs,
         seed=args.seed,
     )

--- a/scripts/train_genotype_ddp.py
+++ b/scripts/train_genotype_ddp.py
@@ -1,9 +1,10 @@
+from confopt.enums import TrainerPresetType
 from confopt.profile.profiles import DiscreteProfile
 from confopt.train import Experiment
 from confopt.train.experiment import DatasetType, SearchSpaceType
 
 if __name__ == "__main__":
-    profile = DiscreteProfile(searchspace_type=SearchSpaceType.DARTS)
+    profile = DiscreteProfile(trainer_preset=TrainerPresetType.DARTS)
     config = profile.get_trainer_config()
     profile.configure_trainer(use_ddp=True)
     config.update({"genotype": profile.get_genotype()})

--- a/src/confopt/enums.py
+++ b/src/confopt/enums.py
@@ -15,6 +15,18 @@ class SearchSpaceType(Enum):
         return self.value
 
 
+class TrainerPresetType(Enum):
+    DARTS = "darts"
+    NB201 = "nb201"
+    NB1SHOT1 = "nb1shot1"
+    TNB101 = "tnb101"
+    BABYDARTS = "baby_darts"
+    RobustDARTS = "robust_darts"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class SamplerType(Enum):
     DARTS = "darts"
     DRNAS = "drnas"

--- a/src/confopt/profile/profiles.py
+++ b/src/confopt/profile/profiles.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from typing_extensions import override
 
-from confopt.enums import SamplerType, SearchSpaceType
+from confopt.enums import SamplerType, TrainerPresetType
 from confopt.searchspace.darts.core.genotypes import DARTSGenotype
 from confopt.utils import get_num_classes
 
@@ -26,13 +26,13 @@ class DARTSProfile(BaseProfile, ABC):
 
     def __init__(
         self,
-        searchspace_type: str | SearchSpaceType,
+        trainer_preset: str | TrainerPresetType,
         epochs: int,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             self.SAMPLER_TYPE,
-            searchspace_type,
+            trainer_preset,
             epochs,
             **kwargs,
         )
@@ -69,7 +69,7 @@ class DARTSProfile(BaseProfile, ABC):
 
         Example:
             >>> from confopt.profile import DARTSProfile
-            >>> darts_profile = DARTSProfile(searchspace='darts', epochs=50)
+            >>> darts_profile = DARTSProfile(trainer_preset='darts', epochs=50)
             >>> darts_profile.configure_sampler(arch_combine_fn='sigmoid')
 
         The accepted keyword arguments should align with the sampler's configuration and
@@ -100,7 +100,7 @@ class GDASProfile(BaseProfile, ABC):
 
     def __init__(
         self,
-        searchspace_type: str | SearchSpaceType,
+        trainer_preset: str | TrainerPresetType,
         epochs: int,
         tau_min: float = 0.1,
         tau_max: float = 10,
@@ -111,7 +111,7 @@ class GDASProfile(BaseProfile, ABC):
 
         super().__init__(
             self.SAMPLER_TYPE,
-            searchspace_type,
+            trainer_preset,
             epochs,
             **kwargs,
         )
@@ -160,7 +160,7 @@ class GDASProfile(BaseProfile, ABC):
 
         Example:
             >>> from confopt.profile import GDASProfile
-            >>> gdas_profile = GDASProfile(searchspace='darts', epochs=50)
+            >>> gdas_profile = GDASProfile(trainer_preset='darts', epochs=50)
             >>> gdas_profile.configure_sampler(tau_min=02, tau_max=20)
 
         The accepted keyword arguments should align with the sampler's configuration and
@@ -201,7 +201,7 @@ class SNASProfile(BaseProfile, ABC):
 
     def __init__(
         self,
-        searchspace_type: str | SearchSpaceType,
+        trainer_preset: str | TrainerPresetType,
         epochs: int,
         temp_init: float = 1.0,
         temp_min: float = 0.03,
@@ -215,7 +215,7 @@ class SNASProfile(BaseProfile, ABC):
 
         super().__init__(  # type: ignore
             self.SAMPLER_TYPE,
-            searchspace_type,
+            trainer_preset,
             epochs,
             **kwargs,
         )
@@ -278,13 +278,13 @@ class DRNASProfile(BaseProfile, ABC):
 
     def __init__(
         self,
-        searchspace_type: str | SearchSpaceType,
+        trainer_preset: str | TrainerPresetType,
         epochs: int,
         **kwargs: Any,
     ) -> None:
         super().__init__(  # type: ignore
             self.SAMPLER_TYPE,
-            searchspace_type,
+            trainer_preset,
             epochs,
             **kwargs,
         )
@@ -388,7 +388,7 @@ class DRNASProfile(BaseProfile, ABC):
 
         Example:
             >>> from confopt.profile import DRNASProfile
-            >>> drnas_profile = DRNASProfile(searchspace='darts', epochs=50)
+            >>> drnas_profile = DRNASProfile(trainer_preset='darts', epochs=50)
             >>> drnas_profile.configure_sampler(arch_combine_fn='sigmoid')
 
         The accepted keyword arguments should align with the sampler's configuration and
@@ -409,7 +409,7 @@ class CompositeProfile(BaseProfile, ABC):
 
     def __init__(
         self,
-        searchspace_type: str | SearchSpaceType,
+        trainer_preset: str | TrainerPresetType,
         samplers: list[str | SamplerType],
         epochs: int,
         # GDAS configs
@@ -436,7 +436,7 @@ class CompositeProfile(BaseProfile, ABC):
 
         super().__init__(  # type: ignore
             self.SAMPLER_TYPE,
-            searchspace_type,
+            trainer_preset,
             epochs,
             **kwargs,
         )
@@ -548,21 +548,21 @@ class CompositeProfile(BaseProfile, ABC):
 class DiscreteProfile:
     def __init__(
         self,
-        searchspace_type: str | SearchSpaceType,
+        trainer_preset: str | TrainerPresetType,
         domain: str | None = None,
         **kwargs: Any,
     ) -> None:
-        self.searchspace_type = (
-            SearchSpaceType(searchspace_type)
-            if isinstance(searchspace_type, str)
-            else searchspace_type
+        self.trainer_preset = (
+            TrainerPresetType(trainer_preset)
+            if isinstance(trainer_preset, str)
+            else trainer_preset
         )
         assert isinstance(
-            self.searchspace_type, SearchSpaceType
-        ), f"Invalid searchspace type: {searchspace_type}"
+            self.trainer_preset, TrainerPresetType
+        ), f"Invalid trainer_preset type: {trainer_preset}"
         self.domain = domain
         self._initialize_trainer_config()
-        self._initializa_genotype()
+        self._initialize_genotype()
         self.configure_trainer(**kwargs)
 
     def get_trainer_config(self) -> dict:
@@ -599,7 +599,7 @@ class DiscreteProfile:
             None
         """
         default_train_config = {
-            "searchspace": self.searchspace_type,
+            "searchspace": self.trainer_preset,
             "lr": 0.025,
             "epochs": 100,
             "optim": "sgd",
@@ -626,7 +626,7 @@ class DiscreteProfile:
         }
         self.train_config = default_train_config
 
-    def _initializa_genotype(self) -> None:
+    def _initialize_genotype(self) -> None:
         """Initializes the genotype for the discrete profile.
         This method sets the genotype of the best DARTS supernet found
         after 50 epochs of running the DARTS optimizer. Thus it is only
@@ -711,7 +711,7 @@ class DiscreteProfile:
 
         Args:
             **config: Arbitrary keyword arguments. Possible depend on the \
-                the search space type. For more information please check the \
+                the trainer preset type. For more information please check the \
                 Parameters of the supernet of each search space.
 
 
@@ -739,7 +739,7 @@ class DiscreteProfile:
             self.extra_config.update(config)
 
     def get_searchspace_config(self, dataset_str: str) -> dict:
-        """Returns the search space configuration based on the search space type.
+        """Returns the search space configuration based on the trainer preset type.
 
         Args:
             dataset_str (str): The dataset string.
@@ -753,27 +753,27 @@ class DiscreteProfile:
             would be passed to as the arguments for creating the new discrete
             model object.
         """
-        if self.searchspace_type == SearchSpaceType.NB201:
+        if self.trainer_preset == TrainerPresetType.NB201:
             searchspace_config = {
                 "N": 5,  # num_cells
                 "C": 16,  # channels
                 "num_classes": get_num_classes(dataset_str),
             }
-        elif self.searchspace_type == SearchSpaceType.DARTS:
+        elif self.trainer_preset == TrainerPresetType.DARTS:
             searchspace_config = {
                 "C": 36,  # init channels
                 "layers": 20,  # number of layers
                 "auxiliary": False,
                 "num_classes": get_num_classes(dataset_str),
             }
-        elif self.searchspace_type == SearchSpaceType.TNB101:
+        elif self.trainer_preset == TrainerPresetType.TNB101:
             assert self.domain is not None, "domain must be specified"
             searchspace_config = {
                 "domain": self.domain,  # type: ignore
                 "num_classes": get_num_classes(dataset_str, domain=self.domain),
             }
         else:
-            raise ValueError("search space is not correct")
+            raise ValueError("trainer preset is not correct")
         if hasattr(self, "searchspace_config"):
             searchspace_config.update(self.searchspace_config)
         return searchspace_config

--- a/src/confopt/train/experiment.py
+++ b/src/confopt/train/experiment.py
@@ -1235,7 +1235,7 @@ if __name__ == "__main__":
     args.epochs = 3
 
     profile = GDASProfile(
-        searchspace_type=searchspace.value,
+        trainer_preset=searchspace.value,
         epochs=args.epochs,
         is_partial_connection=args.is_partial_connector,
         perturbation=args.perturbator,

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -25,7 +25,7 @@ class TestBaseProfile(unittest.TestCase):
             lora_toggle_epochs=None,
             lora_toggle_probability=None,
             seed=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             oles=False,
             calc_gm_score=False,
             prune_epochs=None,
@@ -57,7 +57,7 @@ class TestBaseProfile(unittest.TestCase):
     def test_invalid_configuration(self) -> None:
         profile = BaseProfile(
             "gdas",
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             epochs=1,
             is_partial_connection=True,
             dropout=0.5,
@@ -109,7 +109,7 @@ class TestDartsProfile(unittest.TestCase):
             lora_toggle_epochs=None,
             lora_toggle_probability=None,
             seed=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             oles=False,
             calc_gm_score=False,
             prune_epochs=None,
@@ -132,7 +132,7 @@ class TestDartsProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = DARTSProfile(  # noqa: F841
                 epochs=100,
-                searchspace_type="nb201",
+                trainer_preset="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -143,7 +143,7 @@ class TestDartsProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = DARTSProfile(
             epochs=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"sample_frequency": "epoch"}
@@ -157,7 +157,7 @@ class TestDartsProfile(unittest.TestCase):
             profile.configure_sampler(invalid_config="step")
 
     def test_sampler_post_fn(self) -> None:
-        profile = DARTSProfile(epochs=1, searchspace_type="nb201")
+        profile = DARTSProfile(epochs=1, trainer_preset="nb201")
         assert profile.sampler_config["arch_combine_fn"] == "default" # type: ignore
         sampler_config = {"arch_combine_fn": "sigmoid"}
         profile.configure_sampler(**sampler_config)
@@ -187,7 +187,7 @@ class TestDRNASProfile(unittest.TestCase):
             lora_toggle_epochs=None,
             lora_toggle_probability=None,
             seed=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             oles=False,
             calc_gm_score=False,
             prune_epochs=None,
@@ -210,7 +210,7 @@ class TestDRNASProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = DRNASProfile(  # noqa: F841
                 epochs=100,
-                searchspace_type="nb201",
+                trainer_preset="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -221,7 +221,7 @@ class TestDRNASProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = DRNASProfile(
             epochs=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"sample_frequency": "epoch"}
@@ -235,7 +235,7 @@ class TestDRNASProfile(unittest.TestCase):
             profile.configure_sampler(invalid_config="step")
 
     def test_sampler_post_fn(self) -> None:
-        profile = DRNASProfile(epochs=1, searchspace_type="nb201",)
+        profile = DRNASProfile(epochs=1, trainer_preset="nb201",)
         assert profile.sampler_config["arch_combine_fn"] == "default" # type: ignore
         sampler_config = {"arch_combine_fn": "sigmoid"}
         profile.configure_sampler(**sampler_config)
@@ -267,7 +267,7 @@ class TestGDASProfile(unittest.TestCase):
             lora_toggle_epochs=None,
             lora_toggle_probability=None,
             seed=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             oles=False,
             calc_gm_score=False,
             prune_epochs=None,
@@ -290,7 +290,7 @@ class TestGDASProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = GDASProfile(  # noqa: F841
                 epochs=100,
-                searchspace_type="nb201",
+                trainer_preset="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -301,7 +301,7 @@ class TestGDASProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = GDASProfile(
             epochs=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"tau_max": 12, "tau_min": 0.3}
@@ -338,7 +338,7 @@ class TestSNASProfile(unittest.TestCase):
             lora_toggle_epochs=None,
             lora_toggle_probability=None,
             seed=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             oles=False,
             calc_gm_score=False,
             prune_epochs=None,
@@ -361,7 +361,7 @@ class TestSNASProfile(unittest.TestCase):
         with self.assertRaises(AssertionError):
             profile = SNASProfile(  # noqa: F841
                 epochs=100,
-                searchspace_type="nb201",
+                trainer_preset="nb201",
                 is_partial_connection=True,
                 perturbation="random",
                 sampler_sample_frequency="step",
@@ -372,7 +372,7 @@ class TestSNASProfile(unittest.TestCase):
     def test_sampler_change(self) -> None:
         profile = SNASProfile(
             epochs=100,
-            searchspace_type="nb201",
+            trainer_preset="nb201",
             sampler_sample_frequency="step",
         )
         sampler_config = {"temp_min": 0.5, "temp_init": 1.3}


### PR DESCRIPTION
For all the profiles (**`BaseProfile`** childrens and **`DiscreteProfile`**), `searchspace_type` parameter was confusing as it was also consumed inside the `Experiment` class. 

`searchspace_type` is now renamed to `trainer_preset`. There are corresponding new set of Enums - `TrainerPresetType` introduced.

